### PR TITLE
Add otter.ai

### DIFF
--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -244,6 +244,14 @@
   pricing_source: https://www.opsgenie.com/pricing
   updated_at: 2018-11-08
 
+- name: Otter
+  url: https://www.otter.ai/
+  base_pricing: $8.33 per u/m
+  sso_pricing: $20 per u/m
+  percent_increase: 140%
+  pricing_source: https://otter.ai/pricing
+  updated_at: 2021-07-28
+
 - name: PagerTree
   url: https://pagertree.com
   base_pricing: $10 per u/m


### PR DESCRIPTION
Otter has three paid plans: Pro, Business, Enterprise
Enterprise pricing is not listed, but the only difference between Business and Enterprise is SSO and it requires a minimum of 100 users.