### PR TITLE
removing squadcast who seems to have dropped the tax

### DIFF
--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -383,15 +383,6 @@
   pricing_source: https://www.splashtop.com/pricing
   updated_at: 2021-09-05
 
-- name: Squadcast
-  url: https://www.squadcast.com
-  base_pricing: $9 per u/m
-  sso_pricing: $19 per u/m [^squadcast]
-  footnotes: "[^squadcast]: Upon request, you can also add SSO to Squadcast Pro for an additional $4 per u/m, making it a 44% increase from the base pricing."
-  percent_increase: 111%
-  pricing_source: https://www.squadcast.com/pricing
-  updated_at: 2019-12-21
-
 - name: Stack Overflow
   url: https://stackoverflow.com
   base_pricing: $5 per u/m


### PR DESCRIPTION
Looking at Squadcasts' pricing page now they offer SSO for all
tiers, including the free tier.
