### PR TITLE
Add Smartdraw

### DIFF
--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -385,6 +385,14 @@
   pricing_source: https://slack.com/pricing
   updated_at: 2018-10-17
 
+- name: SmartDraw
+  url: https://smartdraw.com
+  base_pricing: $5.95 per u/m
+  sso_pricing: $49.99 per u/m
+  percent_increase: 740%
+  pricing_source: https://www.smartdraw.com/buy/sdcloud.htm
+  updated_at: 2023-05-09
+
 - name: SmartSheet
   url: https://smartsheet.com
   base_pricing: $25 per u/m

--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -387,11 +387,11 @@
 
 - name: SmartDraw
   url: https://smartdraw.com
-  base_pricing: $5.95 per u/m
-  sso_pricing: $49.99 per u/m
-  percent_increase: 740%
+  base_pricing: $8.25 per u/m
+  sso_pricing: $49.92 per u/m
+  percent_increase: 505%
   pricing_source: https://www.smartdraw.com/buy/sdcloud.htm
-  updated_at: 2023-05-09
+  updated_at: 2023-05-10
 
 - name: SmartSheet
   url: https://smartsheet.com


### PR DESCRIPTION
Smartdraw requires a $3K/year enterprise site license for SSO, vs. $6/u/m ($360/yr) for a team license.