### PR TITLE
fixing typo on pandadoc

### DIFF
--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -316,7 +316,8 @@
 - name: PandaDoc
   url: https://pandadoc.com
   base_pricing: $19 per u/m
-  sso_pricing: Call Us footnotes: "[^PandaDoc]: SSO locked behind Enterprise Call Us"
+  sso_pricing: Call Us 
+  footnotes: "[^PandaDoc]: SSO locked behind Enterprise Call Us"
   percent_increase: ???
   pricing_source: https://pandadoc.com/pricing/
   updated_at: 2023-04-24


### PR DESCRIPTION
panda commit appears to have missed a space between sso_price and footnotes which is causing issues