### PR TITLE
Add Sensu to SSO wall of shame

### DIFF
--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -437,6 +437,14 @@
   pricing_source: https://sentry.io/pricing/
   updated_at: 2018-10-20
 
+- name: Sensu
+  url: https://sensu.io/
+  base_pricing: $0
+  sso_pricing: $3 per node/month
+  percentage_increase: 300%
+  pricing_source: https://sensu.io/pricing
+  updated_at: 2023-11-27
+
 - name: Slack
   url: https://slack.com
   base_pricing: $6.67 per u/m


### PR DESCRIPTION
Sensu only supports SSO for paid tiers, even when self-hosting. [See here for details](https://sensu.io/features/compare).