### PR TITLE
swap to github actions for build, add valdiation, fix identified validation errors

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -1,0 +1,67 @@
+name: Build Jekyll site
+on: [push, pull_request]
+
+permissions:
+  contents: read
+  #pages: write
+  id-token: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install yamale
+
+      - name: Run YAML validator
+        run: |
+          python _build/validator.py
+
+      - name: Run Footnote validator
+        run: |
+          python _build/footnote_validator.py _data/vendors.yml
+
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build
+        uses: actions/jekyll-build-pages@v1
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  # Deploy job
+  deploy:
+    if: github.ref == 'refs/heads/main'
+
+    # Add a dependency to the build job
+    needs:
+      - validate
+      - build
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,5 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.0" if Gem.win_platform?
+
+gem "webrick", "~> 1.8"

--- a/_build/footnote_validator.py
+++ b/_build/footnote_validator.py
@@ -1,0 +1,61 @@
+import yaml
+import re
+import sys
+
+def validate_footnotes(file_path):
+    """
+    Validate that all footnotes in sso_pricing lines have matching definitions.
+
+    Args:
+        file_path (str): Path to the YAML file to validate.
+
+    Returns:
+        list: List of validation errors.
+    """
+    errors = []
+    footnotes = set()
+    sso_pricing_footnotes = set()
+
+    with open(file_path, 'r') as file:
+        data = yaml.safe_load(file)
+
+    # Extract footnotes from footnotes entries
+    for entry in data:
+        if 'footnotes' in entry:
+            match = re.match(r'\[\^(.+)\].*', entry['footnotes'])
+            if match:
+                footnote_name = match.group(1)
+                footnotes.add(footnote_name)
+
+    # Extract footnotes from other entries
+    for entry in data:
+        for key, val in entry.items():
+            if key == "footnotes":
+                continue
+            match = re.search(r'\[\^([^]]+)\]', str(val))
+            if match:
+                sso_pricing_footnote = match.group(1)
+                sso_pricing_footnotes.add(sso_pricing_footnote)
+
+    # Check for footnotes without definitions
+    for footnote in sso_pricing_footnotes:
+        if footnote not in footnotes:
+            errors.append(f"Footnote for '{footnote}' is referenced but has no definition.")
+
+    # Check for definitions without footnotes
+    for footnote in footnotes:
+        if footnote not in sso_pricing_footnotes:
+            errors.append(f"Footnote for '{footnote}' is defined, but is not used.")
+
+    if errors:
+        raise ValueError("Validation errors:\n" + "\n".join(errors))
+
+if __name__ == "__main__":
+    try:
+        validate_footnotes(sys.argv[1])
+        print("No validation errors found.")
+    except ValueError as e:
+        print(f"Found Validation Errors: {e}")
+        print()
+        print(f"Hint: make sure the footnote is declared with a 'footnote:' key and a value that starts with the footnote name, for example: 'footnote: [^vendorname]'. The footnote must also be used in another field to be valid and get displayed. For example:  'sso_pricing: $5/u/m [^vendorname]'." )
+        sys.exit(1)

--- a/_build/schema.yaml
+++ b/_build/schema.yaml
@@ -1,0 +1,14 @@
+list(include('vendor'))
+
+---
+vendor:
+  name: str() 
+  url: str()
+  base_pricing: str()
+  sso_pricing: str()
+  percent_increase: str()
+  pricing_source: any(list(), str(), required=False)
+  pricing_note: str(required=False)
+  footnotes: str(required=False)
+  updated_at: day()
+

--- a/_build/validator.py
+++ b/_build/validator.py
@@ -1,0 +1,15 @@
+import yamale
+
+def main():
+    schema = yamale.make_schema('_build/schema.yaml')
+    data = yamale.make_data('_data/vendors.yml')
+
+    try:
+        yamale.validate(schema, data)
+        print("Validation successful!")
+    except yamale.YamaleError as e:
+        print("Validation failed: {e}")
+        raise
+
+if __name__ == "__main__":
+    main()

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ description: >-
   A list of vendors that treat single sign-on as a luxury feature, not a core
   security requirement.
 
-url: https://robchahin.github.io/sso-wall-of-shame
+url: https://stopthesso.tax
 
 theme: jekyll-theme-cayman
 kramdown:

--- a/_data/vendors.yml
+++ b/_data/vendors.yml
@@ -1,7 +1,7 @@
 - name: Airtable
   url: https://airtable.com
   base_pricing: $10 per u/m
-  sso_pricing: $60 per u/m
+  sso_pricing: $60 per u/m[^airtable-price]
   percent_increase: 500%
   pricing_source: https://airtable.com/pricing
   pricing_note: Quote
@@ -113,7 +113,7 @@
   footnotes: '[^dbt-price]: $20K/year for 5 users minimum for Enterprise edition'
   percent_increase: 233%
   pricing_note: Quote
-  sso_pricing: $333 per u/m
+  sso_pricing: $333 per u/m[^dbt-price]
   updated_at: 2023-04-11
 
 - name: Directus Cloud
@@ -207,30 +207,30 @@
   sso_pricing: $583.33 per u/m [^grammarly]
   percent_increase: 4567%
   pricing_source: https://grammarly.com/business/pricing
-  footnote: "[^grammarly]: SSO doesn't cost more per user but requires a minimum of 50 users. If you only had 10 actual users but wanted SSO, you'd have to pay $583.33/month, instead of $120.83/month"
+  footnotes: "[^grammarly]: SSO doesn't cost more per user but requires a minimum of 50 users. If you only had 10 actual users but wanted SSO, you'd have to pay $583.33/month, instead of $120.83/month"
   updated_at: 2022-04-12
 
 - name: Hakuna
   url: https://www.hakuna.ch
-  base_pricing: 69 CHF for 5 u/m
-  sso_pricing: 139 CHF for 5 u/m
+  base_pricing: 69 CHF for 5 u/m[^hakuna]
+  sso_pricing: 139 CHF for 5 u/m[^hakuna]
   percent_increase: 200%
   pricing_source: https://www.hakuna.ch/preise
-  footnote: "[^hakuna]: Non-linear pricing; price per user decreases with more users"
+  footnotes: "[^hakuna]: Non-linear pricing; price per user decreases with more users"
   updated_at: 2023-10-04
 
 - name: Hotjar
   url: https://www.hotjar.com
-  base_pricing: $32.00 per /m
+  base_pricing: $32.00 per /m[^hotjar]
   sso_pricing: $171.00 per /m
   percent_increase: 434%
   pricing_source: https://www.hotjar.com/pricing
-  footnote: "[^hotjar]: There is a free plan however that is very limited so base pricing is taken on the lowest paid plan"
+  footnotes: "[^hotjar]: There is a free plan however that is very limited so base pricing is taken on the lowest paid plan"
   updated_at: 2023-07-19
 
 - name: Hubspot Marketing
   url: https://www.hubspot.com
-  base_pricing: $40 per month
+  base_pricing: $40 per month[^hubspotmarketing]
   sso_pricing: $3,600 per month
   percent_increase: 8900%
   pricing_source: https://www.hubspot.com/pricing/marketing/starter
@@ -367,8 +367,8 @@
 - name: PandaDoc
   url: https://pandadoc.com
   base_pricing: $19 per u/m
-  sso_pricing: Call Us
-  footnotes: "[^PandaDoc]: SSO locked behind Enterprise Call Us"
+  sso_pricing: Call Us[^pandadoc]
+  footnotes: "[^pandadoc]: SSO locked behind Enterprise Call Us"
   percent_increase: ???
   pricing_source: https://pandadoc.com/pricing/
   updated_at: 2023-04-24
@@ -468,7 +468,7 @@
   url: https://sensu.io/
   base_pricing: $0
   sso_pricing: $3 per node/month
-  percentage_increase: 300%
+  percent_increase: 300%
   pricing_source: https://sensu.io/pricing
   updated_at: 2023-11-27
 
@@ -542,7 +542,7 @@
   sso_pricing: €833.00 per month
   percent_increase: 2885% [^teamviewer]
   pricing_source: https://teamviewer.com/en/buy-now & quote
-  footnote: "[^teamviewer]: Pricing from a quote. TeamViewer's base price is 'TeamViewer Business' & their enterprise-oriented product TeamViewer Tensor is about 10 000€/year."
+  footnotes: "[^teamviewer]: Pricing from a quote. TeamViewer's base price is 'TeamViewer Business' & their enterprise-oriented product TeamViewer Tensor is about 10 000€/year."
   updated_at: 2022-04-12
 
 - name: Twilio

--- a/index.md
+++ b/index.md
@@ -105,3 +105,4 @@ But it costs money to provide SAML support, so we can't offer it for free!
 {% for vendor in site.data.vendors %}
 {{ vendor.footnotes }}
 {% endfor %}
+


### PR DESCRIPTION
Swapping us over to GitHub actions instead of the hidden github pages build process to better surface build failures and also generate downloadable bundles in PRs.

I also added in some validation scripts that will help keep consistency within the YAML files - stumbled across some footnotes not showing up in the final build (because they weren't referenced with the footnote syntax) and so this corrects that and also automates a check to hopefully help prevent issues like it in the future.